### PR TITLE
Fix web worker leaking memory

### DIFF
--- a/src/utils/opus-worker.js
+++ b/src/utils/opus-worker.js
@@ -30,7 +30,17 @@ export default class OpusWorker extends Event {
         this.dispatch('data', data.buffer);
     }
     destroy() {
-        this.worker = null;
+        this.worker.postMessage({
+            type: 'destroy'
+        });
+        // Ideally we could receive a message from the worker
+        // telling us that it's completed processing the "destroy"
+        // command, but until that is possible, this is a reasonable
+        // workaround.
+        setTimeout(() => {
+            this.worker.terminate();
+            this.worker = null;
+        }, 100); // ms
         this.offAll();
     }
 }


### PR DESCRIPTION
Web workers must be cleaned up after they are done being used. Typically this is done in the worker code with a `self.close()` call, but since the worker code is EMScripten port of the opus library, I don't believe we have that option available to us. So, the proposed changes here are to 1) post the `destroy` message to the worker, which tells the opus worker to free some of its memory, and shortly after that 2) Call Worker.terminate() to stop the web worker leaking. For documentation of that function, see https://developer.mozilla.org/en-US/docs/Web/API/Worker/terminate

For reference, I use this library in a production Electron app, and a new decoder is created for every incoming audio message. After a little while (depending on how often messages are received), the app will crash "out of memory" even though there's more than enough memory available on the device. After a while tracking down the root cause, adding these changes on a fork of this repository has cleared up the crashes.